### PR TITLE
Improve repeated field error reporting in beprotojson

### DIFF
--- a/internal/beprotojson/beprotojson.go
+++ b/internal/beprotojson/beprotojson.go
@@ -95,9 +95,17 @@ func (o UnmarshalOptions) setField(m protoreflect.Message, fd protoreflect.Field
 }
 
 func (o UnmarshalOptions) setRepeatedField(m protoreflect.Message, fd protoreflect.FieldDescriptor, val interface{}) error {
+	// Attempt to handle JSON-encoded strings that represent arrays.
+	if s, ok := val.(string); ok {
+		var decoded []interface{}
+		if err := json.Unmarshal([]byte(s), &decoded); err == nil {
+			val = decoded
+		}
+	}
+
 	arr, ok := val.([]interface{})
 	if !ok {
-		return fmt.Errorf("expected array for repeated field, got %T", val)
+		return fmt.Errorf("expected array for repeated field %s, got %T with value %v", fd.Name(), val, val)
 	}
 
 	list := m.Mutable(fd).List()

--- a/internal/beprotojson/beprotojson_test.go
+++ b/internal/beprotojson/beprotojson_test.go
@@ -1,6 +1,7 @@
 package beprotojson
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -197,6 +198,39 @@ func TestUnmarshalOptions(t *testing.T) {
 				t.Errorf("UnmarshalOptions.Unmarshal() diff (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestUnmarshalRepeatedFieldErrors(t *testing.T) {
+	json := `["project1", "oops", "id1", "📚"]`
+	err := Unmarshal([]byte(json), &pb.Project{})
+	if err == nil {
+		t.Fatalf("Unmarshal() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "sources") || !strings.Contains(err.Error(), "oops") {
+		t.Fatalf("error %q does not include field name and value", err)
+	}
+}
+
+func TestUnmarshalRepeatedFieldJSONString(t *testing.T) {
+	json := `["project1", "[[[\"source1\"], \"Source One\"]]", "id1", "📚"]`
+	want := &pb.Project{
+		Title: "project1",
+		Sources: []*pb.Source{
+			{
+				SourceId: &pb.SourceId{SourceId: "source1"},
+				Title:    "Source One",
+			},
+		},
+		ProjectId: "id1",
+		Emoji:     "📚",
+	}
+	got := &pb.Project{}
+	if err := Unmarshal([]byte(json), got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("Unmarshal() diff (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary
- include field name and raw value in repeated field type errors
- attempt to decode JSON-encoded strings for repeated fields
- add unit tests for repeated field error handling and JSON string support

## Testing
- `go test ./internal/beprotojson -count=1`
- `go test ./... -count=1` *(fails: TestDecodeResponse/YouTube_Source_Addition_Response)*

------
https://chatgpt.com/codex/tasks/task_e_68b82b6dec348327b9fc8481c9c40f8e