### PR TITLE
Show last view time in list command

### DIFF
--- a/cmd/nlm/main.go
+++ b/cmd/nlm/main.go
@@ -34,7 +34,7 @@ func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: nlm <command> [arguments]\n\n")
 		fmt.Fprintf(os.Stderr, "Notebook Commands:\n")
-		fmt.Fprintf(os.Stderr, "  list, ls          List all notebooks\n")
+		fmt.Fprintf(os.Stderr, "  list, ls          List recently viewed notebooks\n")
 		fmt.Fprintf(os.Stderr, "  create <title>    Create a new notebook\n")
 		fmt.Fprintf(os.Stderr, "  rm <id>           Delete a notebook\n")
 		fmt.Fprintf(os.Stderr, "  analytics <id>    Show notebook analytics\n\n")
@@ -96,29 +96,29 @@ func run() error {
 	cmd := flag.Arg(0)
 	args := flag.Args()[1:]
 
-   // Prepare options for batchexecute, including debug if requested
-   var optsExec []batchexecute.Option
-   if debug {
-       optsExec = append(optsExec, batchexecute.WithDebug(true))
-   }
-   for i := 0; i < 3; i++ {
+	// Prepare options for batchexecute, including debug if requested
+	var optsExec []batchexecute.Option
+	if debug {
+		optsExec = append(optsExec, batchexecute.WithDebug(true))
+	}
+	for i := 0; i < 3; i++ {
 		if i > 1 {
 			fmt.Fprintln(os.Stderr, "nlm: attempting again to obtain login information")
 			debug = true
 		}
 
-       // Attempt the command; enable debug after second failure as well
-       currentOpts := optsExec
-       if i > 1 && !debug {
-           // turn on debug on retry
-           currentOpts = append(currentOpts, batchexecute.WithDebug(true))
-       }
-       client := api.New(authToken, cookies, currentOpts...)
-       if err := runCmd(client, cmd, args...); err == nil {
-           return nil
-       } else if !errors.Is(err, batchexecute.ErrUnauthorized) {
-           return err
-       }
+		// Attempt the command; enable debug after second failure as well
+		currentOpts := optsExec
+		if i > 1 && !debug {
+			// turn on debug on retry
+			currentOpts = append(currentOpts, batchexecute.WithDebug(true))
+		}
+		client := api.New(authToken, cookies, currentOpts...)
+		if err := runCmd(client, cmd, args...); err == nil {
+			return nil
+		} else if !errors.Is(err, batchexecute.ErrUnauthorized) {
+			return err
+		}
 
 		var err error
 		if authToken, cookies, err = handleAuth(nil, debug); err != nil {
@@ -133,7 +133,11 @@ func runCmd(client *api.Client, cmd string, args ...string) error {
 	switch cmd {
 	// Notebook operations
 	case "list", "ls":
-		err = list(client)
+		var recents []*pb.RecentlyViewedProject
+		recents, err = client.ListRecentlyViewedProjects()
+		if err == nil {
+			err = list(recents)
+		}
 	case "create":
 		if len(args) != 1 {
 			log.Fatal("usage: nlm create <title>")
@@ -255,17 +259,17 @@ func runCmd(client *api.Client, cmd string, args ...string) error {
 }
 
 // Notebook operations
-func list(c *api.Client) error {
-	notebooks, err := c.ListRecentlyViewedProjects()
-	if err != nil {
-		return err
-	}
+func list(recent []*pb.RecentlyViewedProject) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 4, ' ', 0)
-	fmt.Fprintln(w, "ID\tTITLE\tLAST UPDATED")
-	for _, nb := range notebooks {
+	fmt.Fprintln(w, "ID\tTITLE\tLAST VIEWED")
+	for _, nb := range recent {
+		p := nb.GetProject()
+		if p == nil {
+			continue
+		}
 		fmt.Fprintf(w, "%s\t%s\t%s\n",
-			nb.ProjectId, strings.TrimSpace(nb.Emoji)+" "+nb.Title,
-			nb.GetMetadata().GetCreateTime().AsTime().Format(time.RFC3339),
+			p.GetProjectId(), strings.TrimSpace(p.GetEmoji())+" "+p.GetTitle(),
+			nb.GetLastViewTime().AsTime().Format(time.RFC3339),
 		)
 	}
 	return w.Flush()

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -38,7 +38,7 @@ func New(authToken, cookies string, opts ...batchexecute.Option) *Client {
 
 // Project/Notebook operations
 
-func (c *Client) ListRecentlyViewedProjects() ([]*Notebook, error) {
+func (c *Client) ListRecentlyViewedProjects() ([]*pb.RecentlyViewedProject, error) {
 	resp, err := c.rpc.Do(rpc.Call{
 		ID:   rpc.RPCListRecentlyViewedProjects,
 		Args: []interface{}{nil, 1},
@@ -51,13 +51,18 @@ func (c *Client) ListRecentlyViewedProjects() ([]*Notebook, error) {
 	if err := json.Unmarshal(resp, &raw); err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
-	var projects []*pb.Project
+
+	var projects []*pb.RecentlyViewedProject
 	for _, item := range raw {
 		if len(item) == 0 {
 			continue
 		}
-		var p pb.Project
-		if err := beprotojson.Unmarshal(item[0], &p); err != nil {
+		data, err := json.Marshal(item)
+		if err != nil {
+			return nil, fmt.Errorf("marshal project: %w", err)
+		}
+		var p pb.RecentlyViewedProject
+		if err := beprotojson.Unmarshal(data, &p); err != nil {
 			return nil, fmt.Errorf("parse project: %w", err)
 		}
 		projects = append(projects, &p)


### PR DESCRIPTION
## Summary
- Update CLI `list` command to work with `RecentlyViewedProject` entries and display last viewed times.
- Adjust help text and table headers to clarify that the list shows recently viewed notebooks.
- Extend API client to return `RecentlyViewedProject` data including `LastViewTime`.

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b830529cd483278a12707859a80f31