### PR TITLE
Log nlm create output on ID parse failure

### DIFF
--- a/scripts/nlm_workflow.sh
+++ b/scripts/nlm_workflow.sh
@@ -79,7 +79,7 @@ create_notebook() {
   # Extract notebook ID (UUID)
   id=$(echo "$out" | grep -Eo '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
   if [[ -z "$id" ]]; then
-    log "Failed to parse notebook ID from create output"
+    log "Failed to parse notebook ID from output: $out"
     exit 1
   fi
   echo "$id"


### PR DESCRIPTION
## Summary
- log raw `nlm create` output when notebook ID parsing fails

## Testing
- `PATH=/tmp:$PATH NLM_MODE=success bash -lc 'source <(head -n -1 scripts/nlm_workflow.sh); create_notebook "Demo"'`
- `PATH=/tmp:$PATH NLM_MODE=fail bash -lc 'source <(head -n -1 scripts/nlm_workflow.sh); set +e; (create_notebook "Demo"); echo "status:$?"'`
- `go test ./...` *(hangs, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b83ea0a8d083279aeef4b2e48f12aa